### PR TITLE
Calling a callback from context is now optional.

### DIFF
--- a/lib/neo/dci/context.rb
+++ b/lib/neo/dci/context.rb
@@ -19,19 +19,12 @@ module Neo
         context = new(*args)
         context.callback = On.new(*callbacks, &block)
         context.call
-        raise NoCallbackCalled, callbacks unless context.callback.callback
       rescue NotImplementedError
         raise
       end
 
       def call
         raise NotImplementedError
-      end
-
-      class NoCallbackCalled < StandardError
-        def initialize(callbacks)
-          super("No callback called. Available callbacks: #{callbacks.join(', ')}")
-        end
       end
     end
   end

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -44,7 +44,8 @@ class ContextTest < NeoDCICase
     assert_equal [ :foo, :bar ], result
   end
 
-  test "ensure callback called" do
+  test "allow that no callback called" do
+    block_called = false
     context = Class.new(TestContext) do
       callbacks :success
 
@@ -52,11 +53,11 @@ class ContextTest < NeoDCICase
       end
     end
 
-    e = assert_raises Neo::DCI::Context::NoCallbackCalled do
-      context.call do |callback|
-      end
+    context.call do |callback|
+      block_called = true
     end
-    assert_equal "No callback called. Available callbacks: success", e.message
+
+    refute block_called
   end
 
   test "do not overwrite callbacks in subclasses" do


### PR DESCRIPTION
Contexts do not have to call a callback.
Program errors (missing callbacks) should be caught via tests.

Example for a context with an optional callback:

```
class MatchContext < Context
  def initialize(match_uid)
    @match = Match.find(match_uid)
  end

  def call
    if @match
      callback.call :match, match
    end
  end
end
```

/cc @jnbt @techfolio 
